### PR TITLE
Fix iOS or Webkit-based browsers not showing page

### DIFF
--- a/components/gacha.js
+++ b/components/gacha.js
@@ -1,5 +1,6 @@
 import { ref, reactive } from 'vue'
-import items from '../items.json' assert { type: "json" }
+const item_json = await fetch('../items.json')
+const items = await item_json.json()
 
 export default {
     setup() {


### PR DESCRIPTION
As title, this PR is focusing on fixing compatibility for iOS and Webkit-based browsers, which somehow not supporting 
```javascript
import items from '../items.json' assert { type: "json" }
```
statement, causes webpage to be blank when browsing it, making this project unusable.

This PR fixes this problem by using fetch instead of module import, which fixes two problems:
1. iOS compatibility
2. The need of anotating json type